### PR TITLE
Replaced firebase config with common config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,4 @@ docs/pages/versions/*/react-native/*.diff
 .eslintcache
 
 # Firebase config
-lib/FirebaseConfig.ts
+config.ts

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,6 @@
 import firebase from 'firebase';
 import 'firebase/functions';
-import firebaseConfig from './FirebaseConfig';
+import { firebaseConfig } from '../config';
 
 const Firebase = firebase.initializeApp(firebaseConfig);
 export const fns = firebase.functions();


### PR DESCRIPTION
- Replaced firebase config with common config file and updated `.gitignore`
- Project now dependant on a common config file named `config.ts` in the root folder of the project. This file need to include the following constant with appropriate values: `export const firebaseConfig = { }`.