### PR TITLE
Firebase analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ config.ts
 hover-key.json
 
 google-services.json
+GoogleService-Info.plist

--- a/app.json
+++ b/app.json
@@ -27,7 +27,8 @@
         "NSLocationAlwaysUsageDescription": "Your location will only be used to determine if you are in a valid geofence."
       },
       "bundleIdentifier": "com.hoverapp.hover",
-      "buildNumber": "1.0.3"
+      "buildNumber": "1.0.3",
+      "googleServicesFile": "./GoogleService-Info.plist"
     },
     "android": {
       "adaptiveIcon": {

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Hover",
     "slug": "hover",
     "description": "Hover description",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "hover",
@@ -27,7 +27,7 @@
         "NSLocationAlwaysUsageDescription": "Your location will only be used to determine if you are in a valid geofence."
       },
       "bundleIdentifier": "com.hoverapp.hover",
-      "buildNumber": "1.0.3",
+      "buildNumber": "1.0.4",
       "googleServicesFile": "./GoogleService-Info.plist"
     },
     "android": {
@@ -39,7 +39,7 @@
       "permissions": ["ACCESS_COARSE_LOCATION", "ACCESS_FINE_LOCATION", "ACCESS_BACKGROUND_LOCATION"],
       "package": "com.hoverapp.hover",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 10,
+      "versionCode": 11,
       "config": {
         "googleMaps": {
           "apiKey": "AIzaSyC2cQbh0D5hTNvGhn9aML-M5zxzvQdT6Q8"

--- a/components/challenge/OngoingChallengeCard.tsx
+++ b/components/challenge/OngoingChallengeCard.tsx
@@ -47,7 +47,7 @@ export const ChallengeOpponents: React.FC<ChallengeOpponentsProps> = ({ challeng
               user_id={opponent.user.id}
               name={opponent.user.name}
               onPress={() =>
-                Analytics.logEvent('OpenProfile', {
+                Analytics.logEvent('visit_profile', {
                   navigateFrom: 'ChallengeScreen',
                   user: opponent.user.id,
                   navigateTo: 'ProfileScreen',
@@ -96,7 +96,7 @@ const OngoingChallengeCard: React.FC<OngoingChallengeCardProps> = ({ challenge }
         user_id={challenge.created_by.id}
         name={challenge.created_by.name}
         onPress={() =>
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'ChallengeScreen',
             user: challenge.created_by.id,
             navigateTo: 'ProfileScreen',

--- a/components/challenge/OngoingChallengeCard.tsx
+++ b/components/challenge/OngoingChallengeCard.tsx
@@ -10,6 +10,7 @@ import { OpponentFragmentFragment, ChallengeFeedFragmentFragment } from '../../g
 import TouchableProfile from '../general/TouchableProfile';
 import { defaultUserProfile } from '../../helpers/objectMappers';
 import * as Progress from 'react-native-progress';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface ChallengeOpponentsProps {
   challenge: Challenge | ChallengeFeedFragmentFragment;
@@ -41,7 +42,18 @@ export const ChallengeOpponents: React.FC<ChallengeOpponentsProps> = ({ challeng
         <Text style={styles.opponentHeaderText}>Participants</Text>
         {challenge.opponents.map((opponent, index) => {
           return (
-            <TouchableProfile key={index} user_id={opponent.user.id} name={opponent.user.name}>
+            <TouchableProfile
+              key={index}
+              user_id={opponent.user.id}
+              name={opponent.user.name}
+              onPress={() =>
+                Analytics.logEvent('OpenProfile', {
+                  navigateFrom: 'ChallengeScreen',
+                  user: opponent.user.id,
+                  navigateTo: 'ProfileScreen',
+                  purpose: 'Viewing more info on a user',
+                })
+              }>
               <View style={styles.opponentRow}>
                 <View style={styles.opponentAvatar}>
                   <Avatar rounded source={{ uri: opponent.user.picture ?? defaultUserProfile.picture }} size="small" />
@@ -80,7 +92,17 @@ interface OngoingChallengeCardProps {
 const OngoingChallengeCard: React.FC<OngoingChallengeCardProps> = ({ challenge }: OngoingChallengeCardProps) => {
   return (
     <View style={styles.card}>
-      <TouchableProfile user_id={challenge.created_by.id} name={challenge.created_by.name}>
+      <TouchableProfile
+        user_id={challenge.created_by.id}
+        name={challenge.created_by.name}
+        onPress={() =>
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'ChallengeScreen',
+            user: challenge.created_by.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          })
+        }>
         <View style={styles.row}>
           <View style={styles.avatar}>
             <Avatar

--- a/components/challenge/PendingChallengeCard.tsx
+++ b/components/challenge/PendingChallengeCard.tsx
@@ -8,6 +8,7 @@ import { Colors, Typography, Spacing, Buttons } from '../../theme';
 import { Challenge } from '../../types/challengeTypes';
 import { Challenge_Participant_State_Enum } from '../../types/types';
 import TouchableProfile from '../general/TouchableProfile';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface PendingChallengeCardProps {
   challenge: Challenge;
@@ -85,7 +86,17 @@ const PendingChallengeCard: React.FC<PendingChallengeCardProps> = ({ challenge }
 
   return (
     <View style={styles.card}>
-      <TouchableProfile user_id={challenge.created_by.id} name={challenge.created_by.name}>
+      <TouchableProfile
+        user_id={challenge.created_by.id}
+        name={challenge.created_by.name}
+        onPress={() =>
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'ChallengeScreen',
+            user: challenge.created_by.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          })
+        }>
         <View style={styles.row}>
           <View style={styles.avatar}>
             <Avatar
@@ -104,7 +115,18 @@ const PendingChallengeCard: React.FC<PendingChallengeCardProps> = ({ challenge }
         <View style={styles.opponentContainer}>
           <Text style={styles.opponentHeaderText}>Other partcicipants</Text>
           {opponents.map((opponent) => (
-            <TouchableProfile key={opponent.user.id} user_id={opponent.user.id} name={opponent.user.name}>
+            <TouchableProfile
+              key={opponent.user.id}
+              user_id={opponent.user.id}
+              name={opponent.user.name}
+              onPress={() =>
+                Analytics.logEvent('OpenProfile', {
+                  navigateFrom: 'ChallengeScreen',
+                  user: opponent.user.id,
+                  navigateTo: 'ProfileScreen',
+                  purpose: 'Viewing more info on a user',
+                })
+              }>
               <View style={styles.opponentRow}>
                 <View style={styles.opponentAvatar}>
                   <Avatar rounded source={{ uri: opponent.user.picture ?? defaultUserProfile.picture }} size="medium" />

--- a/components/challenge/PendingChallengeCard.tsx
+++ b/components/challenge/PendingChallengeCard.tsx
@@ -90,7 +90,7 @@ const PendingChallengeCard: React.FC<PendingChallengeCardProps> = ({ challenge }
         user_id={challenge.created_by.id}
         name={challenge.created_by.name}
         onPress={() =>
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'ChallengeScreen',
             user: challenge.created_by.id,
             navigateTo: 'ProfileScreen',
@@ -120,7 +120,7 @@ const PendingChallengeCard: React.FC<PendingChallengeCardProps> = ({ challenge }
               user_id={opponent.user.id}
               name={opponent.user.name}
               onPress={() =>
-                Analytics.logEvent('OpenProfile', {
+                Analytics.logEvent('visit_profile', {
                   navigateFrom: 'ChallengeScreen',
                   user: opponent.user.id,
                   navigateTo: 'ProfileScreen',

--- a/components/feed/AchievementFeedCard.tsx
+++ b/components/feed/AchievementFeedCard.tsx
@@ -10,6 +10,7 @@ import { Avatar } from 'react-native-elements';
 import useAuthentication from '../../hooks/useAuthentication';
 import { timeStampToPresentable } from '../../helpers/dateTimeHelpers';
 import Divider from '../general/Divider';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface AchievementFeedCardProps {
   data: AchievementFeedData;
@@ -22,7 +23,17 @@ const AchievementFeedCard: React.FC<AchievementFeedCardProps> = ({ data }: Achie
     <View style={styles.card}>
       <View style={styles.main}>
         <View style={styles.infoContainer}>
-          <TouchableProfile user_id={data.user.id} name={data.user.name}>
+          <TouchableProfile
+            user_id={data.user.id}
+            name={data.user.name}
+            onPress={() =>
+              Analytics.logEvent('OpenProfile', {
+                navigateFrom: 'FeedScreen',
+                user: data.user.id,
+                navigateTo: 'ProfileScreen',
+                purpose: 'Viewing more info on a user',
+              })
+            }>
             <View style={styles.topBar}>
               <Avatar
                 rounded

--- a/components/feed/AchievementFeedCard.tsx
+++ b/components/feed/AchievementFeedCard.tsx
@@ -27,7 +27,7 @@ const AchievementFeedCard: React.FC<AchievementFeedCardProps> = ({ data }: Achie
             user_id={data.user.id}
             name={data.user.name}
             onPress={() =>
-              Analytics.logEvent('OpenProfile', {
+              Analytics.logEvent('visit_profile', {
                 navigateFrom: 'FeedScreen',
                 user: data.user.id,
                 navigateTo: 'ProfileScreen',

--- a/components/feed/ActivityFeedCard.tsx
+++ b/components/feed/ActivityFeedCard.tsx
@@ -14,6 +14,7 @@ import useAuthentication from '../../hooks/useAuthentication';
 import Reaction from './Reaction';
 import { timeStampToPresentable } from '../../helpers/dateTimeHelpers';
 import Divider from '../general/Divider';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface ActivityFeedCardProps {
   data: ActivityFeedData;
@@ -48,7 +49,17 @@ const ActivityFeedCard: React.FC<ActivityFeedCardProps> = ({ data }: ActivityFee
 
   return (
     <View style={styles.card}>
-      <TouchableProfile user_id={data.user.id} name={data.user.name}>
+      <TouchableProfile
+        user_id={data.user.id}
+        name={data.user.name}
+        onPress={() =>
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'FeedScreen',
+            user: data.user.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          })
+        }>
         <View style={styles.flexRowLeft}>
           <View style={styles.topBar}>
             <Avatar

--- a/components/feed/ActivityFeedCard.tsx
+++ b/components/feed/ActivityFeedCard.tsx
@@ -53,7 +53,7 @@ const ActivityFeedCard: React.FC<ActivityFeedCardProps> = ({ data }: ActivityFee
         user_id={data.user.id}
         name={data.user.name}
         onPress={() =>
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'FeedScreen',
             user: data.user.id,
             navigateTo: 'ProfileScreen',

--- a/components/feed/ChallengeFeedCard.tsx
+++ b/components/feed/ChallengeFeedCard.tsx
@@ -11,6 +11,7 @@ import { getAchievementColor } from '../general/Achievement';
 import TouchableProfile from '../general/TouchableProfile';
 import Reaction from './Reaction';
 import useAuthentication from '../../hooks/useAuthentication';
+import * as Analytics from 'expo-firebase-analytics';
 
 type ChallengeFeedCardProps = {
   data: ChallengeFeedData;
@@ -25,7 +26,17 @@ const ChallengeFeedCard: React.FC<ChallengeFeedCardProps> = ({ data }: Challenge
   };
 
   const renderItem = (item: Item, index: number) => (
-    <TouchableProfile user_id={item.id} name={item.name}>
+    <TouchableProfile
+      user_id={item.id}
+      name={item.name}
+      onPress={() =>
+        Analytics.logEvent('OpenProfile', {
+          navigateFrom: 'FeedScreen',
+          user: data.user.id,
+          navigateTo: 'ProfileScreen',
+          purpose: 'Viewing more info on a user',
+        })
+      }>
       <View key={item.id}>
         <ChallengeLeaderboardRow item={item} index={index} />
       </View>
@@ -46,7 +57,17 @@ const ChallengeFeedCard: React.FC<ChallengeFeedCardProps> = ({ data }: Challenge
       <View style={styles.topBar}>
         <Text style={{ ...Typography.headerText }}>We have a winner!</Text>
       </View>
-      <TouchableProfile user_id={data.user.id} name={data.user.name}>
+      <TouchableProfile
+        user_id={data.user.id}
+        name={data.user.name}
+        onPress={() =>
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'FeedScreen',
+            user: data.user.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          })
+        }>
         <View style={styles.topBar}>
           <View style={styles.infoContainer}>
             <Text style={styles.descriptionText}>

--- a/components/feed/ChallengeFeedCard.tsx
+++ b/components/feed/ChallengeFeedCard.tsx
@@ -30,7 +30,7 @@ const ChallengeFeedCard: React.FC<ChallengeFeedCardProps> = ({ data }: Challenge
       user_id={item.id}
       name={item.name}
       onPress={() =>
-        Analytics.logEvent('OpenProfile', {
+        Analytics.logEvent('visit_profile', {
           navigateFrom: 'FeedScreen',
           user: data.user.id,
           navigateTo: 'ProfileScreen',
@@ -61,7 +61,7 @@ const ChallengeFeedCard: React.FC<ChallengeFeedCardProps> = ({ data }: Challenge
         user_id={data.user.id}
         name={data.user.name}
         onPress={() =>
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'FeedScreen',
             user: data.user.id,
             navigateTo: 'ProfileScreen',

--- a/components/feed/Reaction.tsx
+++ b/components/feed/Reaction.tsx
@@ -11,6 +11,7 @@ import { Avatar } from 'react-native-elements';
 import { defaultUserProfile } from '../../helpers/objectMappers';
 import TouchableProfile from '../general/TouchableProfile';
 import useAuthentication from '../../hooks/useAuthentication';
+import * as Analytics from 'expo-firebase-analytics';
 
 const getReactionText = (reactionCount: number, userReacted: boolean) => {
   if (reactionCount === 0) return 'Be the first to react to this activity!';
@@ -90,7 +91,18 @@ const Reaction: React.FC<ReactionProps> = (props: ReactionProps) => {
     };
 
     return (
-      <TouchableProfile user_id={like.user.id} name={like.user.name} onPress={() => setModalVisible(false)}>
+      <TouchableProfile
+        user_id={like.user.id}
+        name={like.user.name}
+        onPress={() => {
+          setModalVisible(false);
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'FeedScreen',
+            user: like.user.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          });
+        }}>
         <View style={styles.row}>
           <View style={styles.avatar}>
             <Avatar rounded source={{ uri: like.user.picture ?? defaultUserProfile.picture }} size="small" />

--- a/components/feed/Reaction.tsx
+++ b/components/feed/Reaction.tsx
@@ -96,7 +96,7 @@ const Reaction: React.FC<ReactionProps> = (props: ReactionProps) => {
         name={like.user.name}
         onPress={() => {
           setModalVisible(false);
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'FeedScreen',
             user: like.user.id,
             navigateTo: 'ProfileScreen',

--- a/components/general/TouchableProfile.tsx
+++ b/components/general/TouchableProfile.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { TouchableOpacity } from 'react-native';
 import useAuthentication from '../../hooks/useAuthentication';
 import { ProfileStackParamList, RootTabParamList } from '../../types/navigationTypes';
-import * as Analytics from 'expo-firebase-analytics';
+
 type BottomNavigationProp = BottomTabNavigationProp<RootTabParamList>;
 type ProfileNavigationProp = BottomTabNavigationProp<ProfileStackParamList>;
 
@@ -33,10 +33,6 @@ const TouchableProfile: React.FC<Props> = ({ user_id, children, name, onPress }:
         titleName: name,
       });
     }
-    await Analytics.logEvent('VisitProfile', {
-      name: 'UserProfile',
-      purpose: 'Opens the another users profile',
-    });
   };
   return (
     <TouchableOpacity

--- a/components/general/TouchableProfile.tsx
+++ b/components/general/TouchableProfile.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { TouchableOpacity } from 'react-native';
 import useAuthentication from '../../hooks/useAuthentication';
 import { ProfileStackParamList, RootTabParamList } from '../../types/navigationTypes';
-
+import * as Analytics from 'expo-firebase-analytics';
 type BottomNavigationProp = BottomTabNavigationProp<RootTabParamList>;
 type ProfileNavigationProp = BottomTabNavigationProp<ProfileStackParamList>;
 
@@ -21,7 +21,7 @@ const TouchableProfile: React.FC<Props> = ({ user_id, children, name, onPress }:
   const navigation = useNavigation();
   const profileNavigator = useNavigation<ProfileNavigationProp>();
 
-  const navigate = () => {
+  const navigate = async () => {
     if (user_id == id) {
       bottomNavigation.navigate('Profile');
       profileNavigator.reset({
@@ -33,6 +33,10 @@ const TouchableProfile: React.FC<Props> = ({ user_id, children, name, onPress }:
         titleName: name,
       });
     }
+    await Analytics.logEvent('VisitProfile', {
+      name: 'UserProfile',
+      purpose: 'Opens the another users profile',
+    });
   };
   return (
     <TouchableOpacity

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -58,7 +58,7 @@ const Leaderboard: React.FC<LeaderboardProps> = (props: LeaderboardProps) => {
         name={item.name}
         key={item.id}
         onPress={() =>
-          Analytics.logEvent('OpenProfile', {
+          Analytics.logEvent('visit_profile', {
             navigateFrom: 'LeaderboardScreen',
             user: item.id,
             navigateTo: 'ProfileScreen',

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -6,6 +6,7 @@ import { HighscoreQuery } from '../../graphql/queries/Highscore.generated';
 import { defaultUserProfile } from '../../helpers/objectMappers';
 import { Colors, Spacing, Typography } from '../../theme';
 import TouchableProfile from '../general/TouchableProfile';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface SortParam {
   data: Item[];
@@ -52,7 +53,18 @@ const Leaderboard: React.FC<LeaderboardProps> = (props: LeaderboardProps) => {
     const rowColor = item.specialRow ? Colors.blueTransparent : index % 2 === 0 ? evenColor : oddColor;
 
     const rowJSx = (
-      <TouchableProfile user_id={item.id} name={item.name} key={item.id}>
+      <TouchableProfile
+        user_id={item.id}
+        name={item.name}
+        key={item.id}
+        onPress={() =>
+          Analytics.logEvent('OpenProfile', {
+            navigateFrom: 'LeaderboardScreen',
+            user: item.id,
+            navigateTo: 'ProfileScreen',
+            purpose: 'Viewing more info on a user',
+          })
+        }>
         <View key={item.id} style={[styles.row, props.rowStyle, { backgroundColor: rowColor }]}>
           <View style={styles.left}>
             <Text

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, ReactNode } from 'react';
 import { User } from 'firebase';
 import Firebase from '../../lib/firebase';
+import * as Analytics from 'expo-firebase-analytics';
 
 interface Props {
   children: ReactNode;
@@ -23,6 +24,7 @@ export const AuthProvider = ({ children }: Props) => {
       if (user) {
         setUserAuthState(user);
         setLoadingUser(false);
+        Analytics.setUserId(user.uid);
       } else {
         setUserAuthState(null);
         setLoadingUser(false);

--- a/components/providers/PushNotificationProvider.tsx
+++ b/components/providers/PushNotificationProvider.tsx
@@ -5,6 +5,8 @@ import { Subscription } from '@unimodules/core';
 import { useUpdateUserPushTokenMutation } from '../../graphql/mutations/UpdateUserPushToken.generated';
 import useAuthentication from '../../hooks/useAuthentication';
 import { storePushToken } from '../../helpers/storage';
+import * as Analytics from 'expo-firebase-analytics';
+import { NotificationResponse } from 'expo-notifications';
 
 interface Props {
   children: ReactNode;
@@ -60,9 +62,15 @@ export const PushNotificationProvider = ({ children }: Props) => {
     });
 
     // This listener is fired whenever a user taps on or interacts with a notification (works when app is foregrounded, backgrounded, or killed)
-    responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      console.log(response);
-    });
+    responseListener.current = Notifications.addNotificationResponseReceivedListener(
+      (response: NotificationResponse) => {
+        console.log(response);
+        Analytics.logEvent('notification_open_event', {
+          user: id,
+          purpose: 'Count number of times a user opens the app when push notification is received.',
+        });
+      },
+    );
 
     return () => {
       if (notificationListener.current) Notifications.removeNotificationSubscription(notificationListener.current);

--- a/components/providers/PushNotificationProvider.tsx
+++ b/components/providers/PushNotificationProvider.tsx
@@ -59,15 +59,21 @@ export const PushNotificationProvider = ({ children }: Props) => {
     // This listener is fired whenever a notification is received while the app is foregrounded
     notificationListener.current = Notifications.addNotificationReceivedListener((notification) => {
       setNotification(notification);
+      Analytics.logEvent('push_notification_event', {
+        user: id,
+        action: 'received',
+        purpose: 'User received push notification.',
+      });
     });
 
     // This listener is fired whenever a user taps on or interacts with a notification (works when app is foregrounded, backgrounded, or killed)
     responseListener.current = Notifications.addNotificationResponseReceivedListener(
       (response: NotificationResponse) => {
         console.log(response);
-        Analytics.logEvent('notification_open_event', {
+        Analytics.logEvent('push_notification_event', {
           user: id,
-          purpose: 'Count number of times a user opens the app when push notification is received.',
+          action: 'open',
+          purpose: 'User open push notification.',
         });
       },
     );

--- a/components/providers/PushNotificationProvider.tsx
+++ b/components/providers/PushNotificationProvider.tsx
@@ -61,9 +61,15 @@ export const PushNotificationProvider = ({ children }: Props) => {
       setNotification(notification);
       Analytics.logEvent('push_notification_event', {
         user: id,
-        action: 'received',
+        action: 'received_in_foreground',
         purpose: 'User received push notification.',
       });
+      if (notification.request.content.title === 'Hi there! I see you are inside a Hover zone') {
+        Analytics.logEvent('PN_inside_geofence_received_foreground', {
+          event: 'received_in_foreground',
+          purpose: 'User receives inside geofence push notification while app in foreground.',
+        });
+      }
     });
 
     // This listener is fired whenever a user taps on or interacts with a notification (works when app is foregrounded, backgrounded, or killed)
@@ -73,8 +79,14 @@ export const PushNotificationProvider = ({ children }: Props) => {
         Analytics.logEvent('push_notification_event', {
           user: id,
           action: 'open',
-          purpose: 'User open push notification.',
+          purpose: 'User opens push notification.',
         });
+        if (response.notification.request.content.title === 'Hi there! I see you are inside a Hover zone') {
+          Analytics.logEvent('PN_inside_geofence_open', {
+            event: 'open',
+            purpose: 'User opens inside geofence push notification.',
+          });
+        }
       },
     );
 

--- a/components/providers/TrackingProvider.tsx
+++ b/components/providers/TrackingProvider.tsx
@@ -203,6 +203,12 @@ export const TrackingProvider = ({ children }: Props) => {
           setFriendId(trackingInfo.friendId ?? '');
           setTrackingWithfriendId(trackingInfo.trackingWithFriendId ?? 0);
           startBackgroundUpdate();
+
+          await Analytics.logEvent('tracking_event_restore_tracking', {
+            action: 'restoreTracking',
+            userId: userId,
+            purpose: 'Tracking is restored and resumed after crash or kill.',
+          });
         }
       }
     };

--- a/components/providers/TrackingProvider.tsx
+++ b/components/providers/TrackingProvider.tsx
@@ -27,6 +27,7 @@ import {
 import { useInterval } from '../../hooks/useInterval';
 import { getDuration, getScore } from '../../helpers/trackingCalculations';
 import * as Location from 'expo-location';
+import * as Analytics from 'expo-firebase-analytics';
 
 export enum TrackingState {
   EXPLORE,
@@ -294,6 +295,11 @@ export const TrackingProvider = ({ children }: Props) => {
     await resetTrackingState();
     startBackgroundUpdate();
     setTrackingState(TrackingState.TRACKING);
+    await Analytics.logEvent('tracking_event', {
+      action: 'start',
+      userId: userId,
+      purpose: 'User start tracking.',
+    });
   };
 
   const stopTracking = async (caption: string) => {
@@ -321,6 +327,11 @@ export const TrackingProvider = ({ children }: Props) => {
       await clearPreviousOutsidePushStorage();
       console.log('Activity inserted to db', response);
       Alert.alert('Upload complete', 'Activity uploaded successfully!');
+      await Analytics.logEvent('tracking_event', {
+        action: 'publish',
+        userId: userId,
+        purpose: 'User publish activity.',
+      });
     } catch (error) {
       Alert.alert('Upload error', error.message);
       console.error('Mutation error', error.message);
@@ -363,6 +374,11 @@ export const TrackingProvider = ({ children }: Props) => {
     setTrackingEnd(undefined);
     await storeNewEndTimestamp(0);
     startBackgroundUpdate();
+    await Analytics.logEvent('tracking_event', {
+      action: 'resume',
+      userId: userId,
+      purpose: 'User resume tracking activity.',
+    });
   };
   const pauseTracking = async () => {
     const pauseEvents = await readPauseEvents();
@@ -382,6 +398,11 @@ export const TrackingProvider = ({ children }: Props) => {
     setTrackingState(TrackingState.EXPLORE);
     await clearTrackingStorage();
     await clearPreviousOutsidePushStorage();
+    await Analytics.logEvent('tracking_event', {
+      action: 'discard',
+      userId: userId,
+      purpose: 'User discards activity.',
+    });
   };
   const updateFriend = async (newFriendId: string, newTrackingWithFriendId: number) => {
     setFriendId(newFriendId);
@@ -398,6 +419,11 @@ export const TrackingProvider = ({ children }: Props) => {
       trackingWithFriendId: newTrackingWithFriendId,
       updatedAtTimestamp: trackingInfo.updatedAtTimestamp,
     } as TrackingInfo);
+    await Analytics.logEvent('tracking_event', {
+      action: 'joinFriend',
+      userId: userId,
+      purpose: 'User tracks with a friend.',
+    });
   };
 
   const value: TrackingContextValues = {

--- a/components/providers/TrackingProvider.tsx
+++ b/components/providers/TrackingProvider.tsx
@@ -295,7 +295,7 @@ export const TrackingProvider = ({ children }: Props) => {
     await resetTrackingState();
     startBackgroundUpdate();
     setTrackingState(TrackingState.TRACKING);
-    await Analytics.logEvent('tracking_event', {
+    await Analytics.logEvent('tracking_event_start', {
       action: 'start',
       userId: userId,
       purpose: 'User start tracking.',
@@ -327,7 +327,7 @@ export const TrackingProvider = ({ children }: Props) => {
       await clearPreviousOutsidePushStorage();
       console.log('Activity inserted to db', response);
       Alert.alert('Upload complete', 'Activity uploaded successfully!');
-      await Analytics.logEvent('tracking_event', {
+      await Analytics.logEvent('tracking_event_publish', {
         action: 'publish',
         userId: userId,
         purpose: 'User publish activity.',
@@ -374,7 +374,7 @@ export const TrackingProvider = ({ children }: Props) => {
     setTrackingEnd(undefined);
     await storeNewEndTimestamp(0);
     startBackgroundUpdate();
-    await Analytics.logEvent('tracking_event', {
+    await Analytics.logEvent('tracking_event_resume', {
       action: 'resume',
       userId: userId,
       purpose: 'User resume tracking activity.',
@@ -398,7 +398,7 @@ export const TrackingProvider = ({ children }: Props) => {
     setTrackingState(TrackingState.EXPLORE);
     await clearTrackingStorage();
     await clearPreviousOutsidePushStorage();
-    await Analytics.logEvent('tracking_event', {
+    await Analytics.logEvent('tracking_event_discard', {
       action: 'discard',
       userId: userId,
       purpose: 'User discards activity.',
@@ -419,7 +419,7 @@ export const TrackingProvider = ({ children }: Props) => {
       trackingWithFriendId: newTrackingWithFriendId,
       updatedAtTimestamp: trackingInfo.updatedAtTimestamp,
     } as TrackingInfo);
-    await Analytics.logEvent('tracking_event', {
+    await Analytics.logEvent('tracking_event_join_friend', {
       action: 'joinFriend',
       userId: userId,
       purpose: 'User tracks with a friend.',

--- a/navigation/RootNavigation.tsx
+++ b/navigation/RootNavigation.tsx
@@ -11,7 +11,6 @@ import DisclaimerScreen from '../screens/disclaimer/DisclaimerScreen';
 import useTracking from '../hooks/useTracking';
 
 export const RootStack = createStackNavigator<RootStackParamList>();
-
 const AppNavigation: React.FC = () => {
   const { user, isLoadingUser } = useAuthentication();
   const locationPermission = useTracking().locationPermission;

--- a/navigation/RootNavigation.tsx
+++ b/navigation/RootNavigation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { useRef } from 'react';
+import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { RootStackParamList } from '../types/navigationTypes';
 import Loading from '../components/general/Loading';
@@ -9,13 +10,27 @@ import useAuthentication from '../hooks/useAuthentication';
 import { DarkTheme } from '../theme/colors';
 import DisclaimerScreen from '../screens/disclaimer/DisclaimerScreen';
 import useTracking from '../hooks/useTracking';
+import * as Analytics from 'expo-firebase-analytics';
 
 export const RootStack = createStackNavigator<RootStackParamList>();
 const AppNavigation: React.FC = () => {
+  const navigationRef = useRef<NavigationContainerRef>(null);
+  const routeNameRef = useRef<string>('');
   const { user, isLoadingUser } = useAuthentication();
   const locationPermission = useTracking().locationPermission;
   return (
-    <NavigationContainer theme={DarkTheme}>
+    <NavigationContainer
+      theme={DarkTheme}
+      ref={navigationRef}
+      onStateChange={async () => {
+        const previousRouteName: string = routeNameRef.current;
+        const currentRouteName: string = navigationRef.current?.getCurrentRoute()?.name ?? '';
+
+        if (previousRouteName !== currentRouteName) {
+          await Analytics.setCurrentScreen(currentRouteName, currentRouteName);
+        }
+        routeNameRef.current = currentRouteName;
+      }}>
       <RootStack.Navigator screenOptions={{ headerShown: false }}>
         {isLoadingUser ? (
           <RootStack.Screen name="Loading" component={Loading} />

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "expo-asset": "~8.2.1",
     "expo-background-fetch": "~8.6.0",
     "expo-constants": "~9.3.3",
+    "expo-firebase-analytics": "~2.6.0",
+    "expo-firebase-core": "~1.3.0",
     "expo-font": "~8.4.0",
     "expo-linking": "~2.0.1",
     "expo-location": "~10.0.0",

--- a/screens/challenge/newchallenge/ChallengeRulesScreen.tsx
+++ b/screens/challenge/newchallenge/ChallengeRulesScreen.tsx
@@ -12,6 +12,7 @@ import { GeoFenceCategory } from '../../../types/geoFenceTypes';
 import { getChallengeTypeFields, getChallengeIcon } from '../../../helpers/challengeMappers';
 import { generateRuleChallengeDescription } from '../../../helpers/decriptionHelper';
 import KeyboardAvoider from '../../../components/keyboard/KeyboardAvoider';
+import * as Analytics from 'expo-firebase-analytics';
 
 type ChallengeRulesRouteProp = RouteProp<NewChallengeStackParamList, 'ChallengeRules'>;
 type NavigationProp = StackNavigationProp<NewChallengeStackParamList>;
@@ -30,6 +31,14 @@ const ChallengeRulesScreen: React.FC<Props> = ({ route, navigation }: Props) => 
   const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
   const [isDisabled, setDisabled] = useState(true);
   const fields = getChallengeTypeFields(route.params.challenge_type);
+
+  useEffect(() => {
+    Analytics.logEvent('new_challenge_pick_rules', {
+      user: route.params.user_id,
+      screen: 'ChallengeRulesScreen',
+      purpose: 'Track the progress of creating av new challenge',
+    });
+  }, []);
 
   const showDatePicker = () => setDatePickerVisibility(true);
   const hideDatePicker = () => setDatePickerVisibility(false);

--- a/screens/challenge/newchallenge/ChallengeTypeScreen.tsx
+++ b/screens/challenge/newchallenge/ChallengeTypeScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, Text, View, FlatList } from 'react-native';
 import Loading from '../../../components/general/Loading';
 import { NewChallengeStackParamList } from '../../../types/navigationTypes';
@@ -9,6 +9,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { useChallengeTypesQuery } from '../../../graphql/queries/ChallengeTypes.generated';
 import { MenuButton } from '../../../components/general/Button';
 import { Challenge_Type_Enum } from '../../../types/types';
+import * as Analytics from 'expo-firebase-analytics';
 
 type ChallengeTypeRouteProp = RouteProp<NewChallengeStackParamList, 'ChallengeType'>;
 type NavigationProp = StackNavigationProp<NewChallengeStackParamList>;
@@ -19,6 +20,14 @@ type Props = {
 };
 const ChallengeTypeScreen: React.FC<Props> = ({ route, navigation }: Props) => {
   const { data: challengeTypes, loading } = useChallengeTypesQuery();
+
+  useEffect(() => {
+    Analytics.logEvent('new_challenge_pick_type', {
+      user: route.params.user_id,
+      screen: 'ChallengeTypeScreen',
+      purpose: 'Track the progress of creating av new challenge',
+    });
+  }, []);
 
   const getIcon = (type: string) => {
     switch (type) {

--- a/screens/challenge/newchallenge/NewChallengeOverviewScreen.tsx
+++ b/screens/challenge/newchallenge/NewChallengeOverviewScreen.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-extra-non-null-assertion */
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, View, Text, Image, Alert } from 'react-native';
 import Button from '../../../components/general/Button';
 import OpponentsRowList from '../../../components/challenge/OpponentsList';
@@ -13,6 +13,7 @@ import { Challenge_Participant_Insert_Input, Challenge_Participant_State_Enum } 
 import Divider from '../../../components/general/Divider';
 import { generateNewChallengeDescription } from '../../../helpers/decriptionHelper';
 import { getGeoFenceImage } from '../../../helpers/geoFenceCalculations';
+import * as Analytics from 'expo-firebase-analytics';
 
 type NewChallengeRouteProp = RouteProp<NewChallengeStackParamList, 'NewChallengeOverview'>;
 type NavigationProp = StackNavigationProp<RootTabParamList, 'Challenge'>;
@@ -23,6 +24,14 @@ type Props = {
 };
 
 const NewChallengeOverviewScreen: React.FC<Props> = ({ route, navigation }: Props) => {
+  useEffect(() => {
+    Analytics.logEvent('new_challenge_overview', {
+      user: route.params.user_id,
+      navigateTo: 'NewChallengeOverviewScreen',
+      purpose: 'Track the progress of creating av new challenge',
+    });
+  }, []);
+
   const createNewChallenge = () =>
     createChallenge({
       variables: {
@@ -37,6 +46,11 @@ const NewChallengeOverviewScreen: React.FC<Props> = ({ route, navigation }: Prop
         navigation.navigate('Challenge');
         console.log('Challenge inserted to db', response);
         Alert.alert('Upload complete', 'Challenge uploaded successfully!');
+        Analytics.logEvent('new_challenge_created', {
+          user: route.params.user_id,
+          screen: 'NewChallengeOverviewScreen',
+          purpose: 'Track the progress of creating av new challenge',
+        });
       })
       .catch((error) => console.error('Mutation error', error.message));
 

--- a/screens/challenge/newchallenge/PickUsersScreen.tsx
+++ b/screens/challenge/newchallenge/PickUsersScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity, Alert, FlatList, ViewStyle } from 'react-native';
 import { Avatar, CheckBox } from 'react-native-elements';
 import Loading from '../../../components/general/Loading';
@@ -10,6 +10,7 @@ import { Buttons, Colors, Spacing, Typography } from '../../../theme';
 import Button from '../../../components/general/Button';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { defaultUserProfile } from '../../../helpers/objectMappers';
+import * as Analytics from 'expo-firebase-analytics';
 
 type PickUsersRouteProp = RouteProp<NewChallengeStackParamList, 'PickUsers'>;
 type NavigationProp = StackNavigationProp<NewChallengeStackParamList>;
@@ -29,6 +30,14 @@ const PickUsersScreen: React.FC<Props> = ({
   const { data: friends, loading } = useGetFriendsQuery({
     variables: { user_id: user_id },
   });
+
+  useEffect(() => {
+    Analytics.logEvent('new_challenge_pick_users', {
+      user: user_id,
+      screen: 'PickUsersScreen',
+      purpose: 'Track the progress of creating av new challenge',
+    });
+  }, []);
 
   const onChecked = (user: ListUserFragmentFragment) => {
     const index = participants.findIndex((x) => x.id == user.id);

--- a/screens/leaderboard/LeaderboardScreen.tsx
+++ b/screens/leaderboard/LeaderboardScreen.tsx
@@ -45,9 +45,6 @@ const LeaderboardScreen: React.FC = () => {
   const id = useAuthentication().user?.uid;
 
   useEffect(() => {
-    Analytics.setCurrentScreen('Leaderboard', 'Leaderboard');
-  }, []);
-  useEffect(() => {
     if (highscoreData) setHighscores(convertToHighscoreList(highscoreData, id));
   }, [highscoreData]);
 

--- a/screens/leaderboard/LeaderboardScreen.tsx
+++ b/screens/leaderboard/LeaderboardScreen.tsx
@@ -10,6 +10,7 @@ import { FontAwesome5 as FAIcon } from '@expo/vector-icons';
 import moment from 'moment';
 import Loading from '../../components/general/Loading';
 import useAuthentication from '../../hooks/useAuthentication';
+import * as Analytics from 'expo-firebase-analytics';
 
 const STATIC_CATEGORIES: PickerItemProps[] = [
   { label: 'All Categories', value: '' },
@@ -42,6 +43,10 @@ const LeaderboardScreen: React.FC = () => {
   });
   const [highscores, setHighscores] = useState<Item[]>([]);
   const id = useAuthentication().user?.uid;
+
+  useEffect(() => {
+    Analytics.setCurrentScreen('Leaderboard');
+  }, []);
   useEffect(() => {
     if (highscoreData) setHighscores(convertToHighscoreList(highscoreData, id));
   }, [highscoreData]);

--- a/screens/leaderboard/LeaderboardScreen.tsx
+++ b/screens/leaderboard/LeaderboardScreen.tsx
@@ -45,7 +45,7 @@ const LeaderboardScreen: React.FC = () => {
   const id = useAuthentication().user?.uid;
 
   useEffect(() => {
-    Analytics.setCurrentScreen('Leaderboard');
+    Analytics.setCurrentScreen('Leaderboard', 'Leaderboard');
   }, []);
   useEffect(() => {
     if (highscoreData) setHighscores(convertToHighscoreList(highscoreData, id));

--- a/screens/leaderboard/LeaderboardScreen.tsx
+++ b/screens/leaderboard/LeaderboardScreen.tsx
@@ -10,7 +10,6 @@ import { FontAwesome5 as FAIcon } from '@expo/vector-icons';
 import moment from 'moment';
 import Loading from '../../components/general/Loading';
 import useAuthentication from '../../hooks/useAuthentication';
-import * as Analytics from 'expo-firebase-analytics';
 
 const STATIC_CATEGORIES: PickerItemProps[] = [
   { label: 'All Categories', value: '' },

--- a/tasks.ts
+++ b/tasks.ts
@@ -16,6 +16,7 @@ import { sendPushNotification } from './helpers/pushNotifications';
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
+import * as Analytics from 'expo-firebase-analytics';
 import Constants from 'expo-constants';
 
 export const LOCATION_BACKGROUND_TRACKING = 'location-background-tracking';
@@ -131,6 +132,12 @@ TaskManager.defineTask(NOTIFICATION_WHEN_INSIDE_GEOFENCE, async () => {
               false,
             );
             storePreviousInsideGeofencePush(insideGeoFence.id);
+
+            Analytics.logEvent('PN_inside_geofence_sent', {
+              event: 'sent',
+              purpose: 'User open push notification.',
+            });
+
             return BackgroundFetch.Result.NewData;
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7595,6 +7595,23 @@ expo-file-system@~9.3.0:
   dependencies:
     uuid "^3.4.0"
 
+expo-firebase-analytics@~2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/expo-firebase-analytics/-/expo-firebase-analytics-2.6.0.tgz#6c549ed2dceecb22d7d7160034a00896963d38a3"
+  integrity sha512-ciLHxYKfS0Oih184ckVJyYj95fWvK+xfDXG9yOkpzow/NIf9snp8ziXSMyJTwFg93bNr3uqvKxk985LSvEPe9Q==
+  dependencies:
+    expo-firebase-core "~1.2.0"
+
+expo-firebase-core@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/expo-firebase-core/-/expo-firebase-core-1.2.0.tgz#1f41d777cb04e19f495d27491b1596bdeb233f95"
+  integrity sha512-ojqiJLlH5BXQsrElPOtYsO0tHR2333mRDxV625Y0NQyjFBF17NQxlmCCkyh2uGO94LgcZTfB13SMiNHOe9RcZQ==
+
+expo-firebase-core@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expo-firebase-core/-/expo-firebase-core-1.3.0.tgz#83da7f6454b710d55c0ddc3dfb3d9dd8506086ed"
+  integrity sha512-aSJymsdPU1qkq5f6hU+B+K+xOMMCKjnXnHWQ/2gdPcNvuoQdwMn6RYseIZ43/IXjL6LEnHY7VlANMtYEH2Wx5Q==
+
 expo-font@~8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/expo-font/-/expo-font-8.4.0.tgz#7cb4cc9d852dd8d0977ce425146b94221b40c1d5"


### PR DESCRIPTION
Added analytics for:
* visit_profile
* push_notification_event
* screen_views, which logs what screens the users open

Tracking events:
Funnel of start -> discard, publish
* tracking_event_start
* tracking_event_resume
* tracking_event_discard
* tracking_event_publish
* tracking_event_join_friend
* tracking_event_restore_tracking
* tracking_event_publish

Create new challenge funnel events:
* new_challenge_pick_users
* new_challenge_pick_type
* new_challenge_pick_rules
* new_challenge_overview
* new_challenge_created

Inside geofence push notification event logging. we would like to study the difference between "sent" and "open"
* PN_inside_geofence_sent
* PN_inside_geofence_received_foreground
* PN_inside_geofence_open